### PR TITLE
Sync IDP Restriction Module with BC SSO upstream implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Please follow Keycloak's documentation on Service Provider Interfaces (SPIs). At
 - Copying custom theme to `themes` folder
 - Clearing cache and restarting Keycloak.
 
-For detailed commands, please refer to [this RFC document](https://proactionca.ent.cgi.com/confluence/display/BCMOHAM/RFC-20240920-01-BCMOHAD-25401-TEST-KEYCLOAK-Deploy_Idp_Restriction_Module).
+For detailed commands, please refer to [this RFC document](https://hlth.atlassian.net/wiki/spaces/HA/pages/515650143/RFC-20240920-01-BCMOHAD-25401-TEST-KEYCLOAK-Deploy_Idp_Restriction_Module).
 For more information regarding clearing Keycloak cache, please refer to [moh-am-themes repository](https://github.com/bcgov/moh-am-themes)
 
 According to the Keycloak documentation, "After registering new providers or dependencies, Keycloak needs to be re-built

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <keycloak.version>26.1.1</keycloak.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <bcsso.source.commit>694832936274cb654b25d94e9cd20fd99e580d15</bcsso.source.commit>
+    <bcsso.source.url>https://github.com/bcgov/sso-keycloak/</bcsso.source.url>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>ca.bc.gov.hlth</groupId>
   <artifactId>IdpRestrictionModule</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <name>IdpRestrictionModule</name>
   <url>http://maven.apache.org</url>
 
@@ -14,6 +14,7 @@
     <maven.compiler.target>17</maven.compiler.target>
     <keycloak.version>26.1.1</keycloak.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <bcsso.source.commit>694832936274cb654b25d94e9cd20fd99e580d15</bcsso.source.commit>
   </properties>
 
   <dependencies>

--- a/src/main/java/ca/bc/gov/hlth/auth/provider/authenticator/CookieStopAuthenticator.java
+++ b/src/main/java/ca/bc/gov/hlth/auth/provider/authenticator/CookieStopAuthenticator.java
@@ -1,17 +1,35 @@
 package ca.bc.gov.hlth.auth.provider.authenticator;
 
 import jakarta.ws.rs.core.MultivaluedMap;
+
+import org.jboss.logging.Logger;
 import org.keycloak.authentication.AuthenticationFlowContext;
 import org.keycloak.authentication.Authenticator;
 import org.keycloak.constants.AdapterConstants;
 import org.keycloak.models.*;
 import org.keycloak.protocol.LoginProtocol;
 import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.services.messages.Messages;
 import org.keycloak.sessions.AuthenticationSessionModel;
 
 import java.util.Map;
 
+/**
+ * Source: BC Gov SSO Keycloak extensions
+ * https://github.com/bcgov/sso-keycloak
+ *
+ * Original author: Junmin Ahn
+ *
+ * This class is derived from the BC SSO project but copied into the
+ * HLTH IDP Restriction Module because the upstream extension is not
+ * published as a standalone artifact. Package names and minor changes
+ * were made to integrate with the HLTH Keycloak deployment.
+ *
+ * @author <a href="mailto:junmin@button.is">Junmin Ahn</a>
+ */
 public class CookieStopAuthenticator implements Authenticator {
+
+    private static final Logger logger = Logger.getLogger(CookieStopAuthenticator.class);
 
     @Override
     public boolean requiresUser() {
@@ -20,6 +38,7 @@ public class CookieStopAuthenticator implements Authenticator {
 
     @Override
     public void authenticate(AuthenticationFlowContext context) {
+
         AuthenticationManager.AuthResult authResult = AuthenticationManager.authenticateIdentityCookie(
                 context.getSession(), context.getRealm(), true);
 
@@ -29,18 +48,42 @@ public class CookieStopAuthenticator implements Authenticator {
             return;
         }
 
-        AuthenticationSessionModel authSession = context.getAuthenticationSession();
-        LoginProtocol protocol = context.getSession().getProvider(LoginProtocol.class, authSession.getProtocol());
-        context.setUser(authResult.getUser());
+        AuthenticationSessionModel currentAuthSession = context.getAuthenticationSession();
+
+        LoginProtocol protocol = context.getSession().getProvider(LoginProtocol.class, currentAuthSession.getProtocol());
+
+        UserSessionModel parentAuthUserSession = context.getSession().sessions().getUserSession(context.getRealm(),
+                context.getAuthenticationSession().getParentSession().getId());
+        String clientUUID = currentAuthSession.getClient().getId();
+        AuthenticatedClientSessionModel clientSessionModel = authResult.getSession()
+                .getAuthenticatedClientSessionByClient(clientUUID);
+
+        UserSessionProvider userSessionProvider = context.getSession().sessions();
+
+        String existingSessionIdp = authResult.getSession().getNotes().get("identity_provider");
+
+        Map<String, ClientScopeModel> clientScopes = context.getAuthenticationSession().getClient().getClientScopes(true);
+
+        // Attach user to this flow only when user has a valid parent authentication
+        // session and,
+        // - Current client session exists or,
+        // - Current client session does not exist and client scopes contains
+        // authenticated IDP
+        if (parentAuthUserSession != null && (clientSessionModel != null
+                || (clientSessionModel == null && clientScopes.containsKey(existingSessionIdp)))) {
+            context.setUser(authResult.getUser());
+        }
 
         // 2. if re-authentication is required, proceed to login process
-        if (protocol.requireReauthentication(authResult.getSession(), authSession)) {
+        if (protocol.requireReauthentication(authResult.getSession(), currentAuthSession)) {
+            currentAuthSession.setAuthNote(AuthenticationManager.FORCED_REAUTHENTICATION, "true");
+            context.setForwardedInfoMessage(Messages.REAUTHENTICATE);
             context.attempted();
             return;
         }
 
         MultivaluedMap<String, String> queryParams = context.getUriInfo().getQueryParameters();
-        String sessIdp = authResult.getSession().getNotes().get("identity_provider");
+
         // 3. If a target IDP is passed via "kc_idp_hint" query param, and
         // i. the target IDP is enabled;
         // ii. the target IDP is allowed for the authenticating client;
@@ -49,16 +92,14 @@ public class CookieStopAuthenticator implements Authenticator {
         if (queryParams.containsKey(AdapterConstants.KC_IDP_HINT)) {
             String authIdp = queryParams.getFirst(AdapterConstants.KC_IDP_HINT);
 
-
             if (authIdp != null && !authIdp.trim().isEmpty()) {
                 IdentityProviderModel idp = context.getSession().identityProviders().getByAlias(authIdp);
-                Map<String, ClientScopeModel> scopes = context.getAuthenticationSession().getClient().getClientScopes(true);
 
                 if (idp != null
                         && idp.isEnabled()
-                        && (scopes.containsKey(authIdp) || scopes.containsKey(authIdp + "-saml"))
-                        && !authIdp.equals(sessIdp)) {
-                    UserSessionProvider userSessionProvider = context.getSession().sessions();
+                        && (clientScopes.containsKey(authIdp) || clientScopes.containsKey(authIdp + "-saml"))
+                        && !authIdp.equalsIgnoreCase(existingSessionIdp)) {
+
                     userSessionProvider.removeUserSession(context.getRealm(), authResult.getSession());
                     context.attempted();
                     return;
@@ -66,24 +107,24 @@ public class CookieStopAuthenticator implements Authenticator {
             }
         }
 
-        // 4. If Cookie session is tied with forbidden IDP
-        Map<String, ClientScopeModel> scopes = context.getAuthenticationSession().getClient().getClientScopes(true);
-        if(!scopes.containsKey(sessIdp) && !scopes.containsKey(sessIdp + "-saml")){
-            UserSessionProvider userSessionProvider = context.getSession().sessions();
+        // If parent authentication session is valid and client session exists or if
+        // current client session does not exist but contains authenticated IDP
+        if (parentAuthUserSession != null && (clientSessionModel != null
+                || (clientSessionModel == null && clientScopes.containsKey(existingSessionIdp)))) {
+            context.getAuthenticationSession().setAuthNote(AuthenticationManager.SSO_AUTH,
+                    "true");
+            context.attachUserSession(authResult.getSession());
+            context.success();
+        } else {
             userSessionProvider.removeUserSession(context.getRealm(), authResult.getSession());
             context.attempted();
             return;
         }
-
-        // 5. Otherwise, attach the exisiting session to the user
-        context.getAuthenticationSession().setAuthNote(AuthenticationManager.SSO_AUTH, "true");
-        context.setUser(authResult.getUser());
-        context.attachUserSession(authResult.getSession());
-        context.success();
     }
 
     @Override
-    public void action(AuthenticationFlowContext context) { /* This is ok */ }
+    public void action(AuthenticationFlowContext context) {
+        /* This is ok */ }
 
     @Override
     public boolean configuredFor(KeycloakSession session, RealmModel realm, UserModel user) {
@@ -91,8 +132,10 @@ public class CookieStopAuthenticator implements Authenticator {
     }
 
     @Override
-    public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) { /* This is ok */ }
+    public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+        /* This is ok */ }
 
     @Override
-    public void close() { /* This is ok */ }
+    public void close() {
+        /* This is ok */ }
 }

--- a/src/main/java/ca/bc/gov/hlth/auth/provider/authenticator/IdentityProviderStopAuthenticator.java
+++ b/src/main/java/ca/bc/gov/hlth/auth/provider/authenticator/IdentityProviderStopAuthenticator.java
@@ -17,6 +17,20 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+/**
+ * Source: BC Gov SSO Keycloak extensions
+ * https://github.com/bcgov/sso-keycloak
+ *
+ * Original author: Junmin Ahn
+ *
+ * This class is derived from the BC SSO project but copied into the
+ * HLTH IDP Restriction Module because the upstream extension is not
+ * published as a standalone artifact. Package names and minor changes
+ * were made to integrate with the HLTH Keycloak deployment.
+ *
+ * @author <a href="mailto:junmin@button.is">Junmin Ahn</a>
+ */
 public class IdentityProviderStopAuthenticator implements Authenticator {
 
     private static final Logger logger = Logger.getLogger(IdentityProviderStopAuthenticator.class);
@@ -27,8 +41,7 @@ public class IdentityProviderStopAuthenticator implements Authenticator {
     public void authenticate(AuthenticationFlowContext context) {
         List<IdentityProviderModel> allowedIdps = new ArrayList<>();
         List<IdentityProviderModel> realmIdps = context.getSession().identityProviders().getAllStream().toList();
-        Map<String, ClientScopeModel> scopes =
-                context.getAuthenticationSession().getClient().getClientScopes(true);
+        Map<String, ClientScopeModel> scopes = context.getAuthenticationSession().getClient().getClientScopes(true);
 
         for (IdentityProviderModel ridp : realmIdps) {
             String oidcAlias = ridp.getAlias();
@@ -45,8 +58,7 @@ public class IdentityProviderStopAuthenticator implements Authenticator {
             redirect(context, firstIdp, null);
         } else if (allowedIdps.size() > 1) {
             if (context.getUriInfo().getQueryParameters().containsKey(AdapterConstants.KC_IDP_HINT)) {
-                String hintIdp =
-                        context.getUriInfo().getQueryParameters().getFirst(AdapterConstants.KC_IDP_HINT);
+                String hintIdp = context.getUriInfo().getQueryParameters().getFirst(AdapterConstants.KC_IDP_HINT);
 
                 if (hintIdp != null && !hintIdp.equals("")) {
                     for (IdentityProviderModel aidp : allowedIdps) {
@@ -68,35 +80,32 @@ public class IdentityProviderStopAuthenticator implements Authenticator {
     }
 
     private void redirect(AuthenticationFlowContext context, IdentityProviderModel idp, String loginHint) {
-        String accessCode =
-                new ClientSessionCode<>(
-                        context.getSession(), context.getRealm(), context.getAuthenticationSession())
-                        .getOrGenerateCode();
+        String accessCode = new ClientSessionCode<>(
+                context.getSession(), context.getRealm(), context.getAuthenticationSession())
+                .getOrGenerateCode();
         String clientId = context.getAuthenticationSession().getClient().getClientId();
-        String tabId = context.getAuthenticationSession().getTabId();
         String clientData = AuthenticationProcessor.getClientData(context.getSession(), context.getAuthenticationSession());
-        URI location =
-                Urls.identityProviderAuthnRequest(
-                        context.getUriInfo().getBaseUri(),
-                        idp.getAlias(),
-                        context.getRealm().getName(),
-                        accessCode,
-                        clientId,
-                        tabId,
-                        clientData,
-                        loginHint);
+        String tabId = context.getAuthenticationSession().getTabId();
+        URI location = Urls.identityProviderAuthnRequest(
+                context.getUriInfo().getBaseUri(),
+                idp.getAlias(),
+                context.getRealm().getName(),
+                accessCode,
+                clientId,
+                tabId,
+                clientData, loginHint);
         if (context.getAuthenticationSession().getClientNote(OAuth2Constants.DISPLAY) != null) {
-            location =
-                    UriBuilder.fromUri(location)
-                            .queryParam(
-                                    OAuth2Constants.DISPLAY,
-                                    context.getAuthenticationSession().getClientNote(OAuth2Constants.DISPLAY))
-                            .build();
+            location = UriBuilder.fromUri(location)
+                    .queryParam(
+                            OAuth2Constants.DISPLAY,
+                            context.getAuthenticationSession().getClientNote(OAuth2Constants.DISPLAY))
+                    .build();
         }
 
         Response response = Response.seeOther(location).build();
 
-        // will forward the request to the IDP with prompt=none if the IDP accepts forwards with
+        // will forward the request to the IDP with prompt=none if the IDP accepts
+        // forwards with
         // prompt=none.
         if ("none"
                 .equals(
@@ -111,7 +120,8 @@ public class IdentityProviderStopAuthenticator implements Authenticator {
     }
 
     @Override
-    public void action(AuthenticationFlowContext context) { /* This is ok */ }
+    public void action(AuthenticationFlowContext context) {
+        /* This is ok */ }
 
     @Override
     public boolean requiresUser() {
@@ -124,8 +134,10 @@ public class IdentityProviderStopAuthenticator implements Authenticator {
     }
 
     @Override
-    public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) { /* This is ok */ }
+    public void setRequiredActions(KeycloakSession session, RealmModel realm, UserModel user) {
+        /* This is ok */ }
 
     @Override
-    public void close() { /* This is ok */ }
+    public void close() {
+        /* This is ok */ }
 }

--- a/src/main/java/ca/bc/gov/hlth/auth/provider/browser/IdentityProviderStopForm.java
+++ b/src/main/java/ca/bc/gov/hlth/auth/provider/browser/IdentityProviderStopForm.java
@@ -1,27 +1,37 @@
 package ca.bc.gov.hlth.auth.provider.browser;
 
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import org.keycloak.authentication.Authenticator;
+import org.keycloak.constants.AdapterConstants;
 
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 import org.keycloak.authentication.AuthenticationFlowContext;
-import org.keycloak.authentication.authenticators.browser.AbstractUsernameFormAuthenticator;
 import org.keycloak.forms.login.LoginFormsProvider;
-import org.keycloak.models.ClientScopeModel;
-import org.keycloak.models.IdentityProviderModel;
-import org.keycloak.models.KeycloakSession;
-import org.keycloak.models.RealmModel;
-import org.keycloak.models.UserModel;
+import org.keycloak.models.*;
 import org.keycloak.services.ServicesLogger;
 import org.keycloak.services.managers.AuthenticationManager;
 
-public class IdentityProviderStopForm extends AbstractUsernameFormAuthenticator {
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Source: BC Gov SSO Keycloak extensions
+ * https://github.com/bcgov/sso-keycloak
+ *
+ * Original author: Junmin Ahn
+ *
+ * This class is derived from the BC SSO project but copied into the
+ * HLTH IDP Restriction Module because the upstream extension is not
+ * published as a standalone artifact. Package names and minor changes
+ * were made to integrate with the HLTH Keycloak deployment.
+ *
+ * @author <a href="mailto:junmin@button.is">Junmin Ahn</a>
+ */
+public class IdentityProviderStopForm implements Authenticator {
     protected static ServicesLogger log = ServicesLogger.LOGGER;
 
     @Override
@@ -32,8 +42,7 @@ public class IdentityProviderStopForm extends AbstractUsernameFormAuthenticator 
     @Override
     public void authenticate(AuthenticationFlowContext context) {
         List<IdentityProviderModel> realmIdps = context.getSession().identityProviders().getAllStream().toList();
-        Map<String, ClientScopeModel> scopes =
-                context.getAuthenticationSession().getClient().getClientScopes(true);
+        Map<String, ClientScopeModel> scopes = context.getAuthenticationSession().getClient().getClientScopes(true);
 
         Map<String, Map<String, String>> idpContext = new HashMap<>();
 
@@ -50,14 +59,34 @@ public class IdentityProviderStopForm extends AbstractUsernameFormAuthenticator 
                     data.put("tooltip", tooltip);
                 }
 
+                String social = ridp.getConfig().get("social");
+                if ("true".equals(social)) {
+                    data.put("social", social);
+                }
+
                 idpContext.put(oidcAlias, data);
             }
         }
 
+        // if kc_idp_hint is set and matches one of the enabled idps then skip the form
+        if (context.getUriInfo().getQueryParameters().containsKey(AdapterConstants.KC_IDP_HINT)) {
+            String hintIdp = context.getUriInfo().getQueryParameters().getFirst(AdapterConstants.KC_IDP_HINT);
+            if (hintIdp != null && !hintIdp.equals("") && idpContext.containsKey(hintIdp)) {
+                context.attempted();
+                return;
+            }
+        }
+
+        // if only one IDP is enabled then skip the form
+        if (!idpContext.isEmpty() && idpContext.size() == 1) {
+            context.attempted();
+            return;
+        }
+
         MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
 
-        ObjectMapper objectMapper = new ObjectMapper();
         try {
+            ObjectMapper objectMapper = new ObjectMapper();
             String json = objectMapper.writeValueAsString(idpContext);
             log.tracef("idp context: %s", json);
             formData.add(AuthenticationManager.FORM_USERNAME, json);
@@ -79,7 +108,8 @@ public class IdentityProviderStopForm extends AbstractUsernameFormAuthenticator 
             AuthenticationFlowContext context, MultivaluedMap<String, String> formData) {
         LoginFormsProvider forms = context.form();
 
-        if (formData.size() > 0) forms.setFormData(formData);
+        if (formData.size() > 0)
+            forms.setFormData(formData);
 
         return forms.createLoginUsernamePassword();
     }
@@ -96,5 +126,6 @@ public class IdentityProviderStopForm extends AbstractUsernameFormAuthenticator 
     }
 
     @Override
-    public void close() {}
+    public void close() {
+        /* This is ok */ }
 }


### PR DESCRIPTION
This PR updates the HLTH IDP Restriction Module to align with the BC SSO upstream implementation.

Changes:
- Replaced CookieStopAuthenticator, IdentityProviderStopAuthenticator, and IdentityProviderStopForm with versions from BC SSO
- Updated package names for HLTH module
- Kept existing authenticator factory IDs to avoid changes to Keycloak browser flows
- Did not include unrelated authenticators present in the BC SSO repository

Reason:
The BC SSO module is not published as a standalone artifact, so required classes are copied and maintained locally.

Testing:
- Local Keycloak 26.1.2 environment
- IDIR and PHSA login flows
- IDP restriction via client scopes
- kc_idp_hint behavior